### PR TITLE
remove the 16 extra bytes from the DATA section and fix Img3Elements padding

### DIFF
--- a/ipsw-patch/img3.c
+++ b/ipsw-patch/img3.c
@@ -194,7 +194,7 @@ size_t writeImg3(AbstractFile* file, const void* data, size_t len) {
 
 	while((info->offset + (size_t)len) > info->data->header->dataSize) {
 		info->data->header->dataSize = info->offset + (size_t)len;
-		info->data->header->size = (((info->data->header->dataSize + 16) / 16) * 16) + sizeof(AppleImg3Header);
+		info->data->header->size = info->data->header->dataSize + sizeof(AppleImg3Header);
 		if(info->data->header->size % 0x4 != 0) {
 			info->data->header->size += 0x4 - (info->data->header->size % 0x4);
 		}
@@ -386,11 +386,17 @@ void writeImg3Root(AbstractFile* file, Img3Element* element, Img3Info* info) {
 }
 
 void writeImg3Default(AbstractFile* file, Img3Element* element, Img3Info* info) {
-        const char zeros[0x10] = {0};
+    
+    size_t paddingSize = (element->header->size - sizeof(AppleImg3Header)) - element->header->dataSize;
+    char zeros[paddingSize];
+    
 	file->write(file, element->data, element->header->dataSize);
-	if((element->header->size - sizeof(AppleImg3Header)) > element->header->dataSize) {
-		file->write(file, zeros, (element->header->size - sizeof(AppleImg3Header)) - element->header->dataSize);
-	}
+    
+    if(paddingSize > 0)
+    {
+        memset(zeros, 0, paddingSize);
+		file->write(file, zeros, paddingSize);
+    }
 }
 
 void writeImg3KBAG(AbstractFile* file, Img3Element* element, Img3Info* info) {


### PR DESCRIPTION
Here is a little story to explain my PR:

I was trying to generate the `PartialDigest` of an img3 file (iBSS from iPhone3,1_6.1.3_10B329) using `tss_get_partial_hash_from_file` function from `MobileDevice.framework`. It was working perfectly with the original iBSS, so I tried with the same iBSS which had been previously decrypted and re-encrypted with `xpwntool`, but this time it did not work:
`tss_get_partial_hash: ih_buffer_len(65928) + 8 is not a multiple of 64`, where `65928` is the SHSH offset.

As I was expecting both iBSSs to be identical (since I decrypted and encrypted back the iBSS without modifying the DATA section), I didn't understand in the first place why the SHSH offset from the original iBSS + 8 would be a multiple of 64 and not the one from the second iBSS.

By comparing both iBSSs, I found the following differences in the second iBSS:
- 16 extra bytes of zero's are appended to the end of the `DATA` section (which increased by 16 the total size of the img3, the total size minus the img3 header size, the SHSH offset size and the data size of the `DATA` section)
- in the second `KBAG` section, some padding bytes were replaced by bytes with random values.

The first issue was caused by the 16 extra bytes added in the `writeImg3` function, and the second issue was caused by the padding bytes array limited to 0x10 bytes in the `writeImg3Default`.
I fixed the first issue by removing those 16 extra bytes, and I fixed the second one by making the padding bytes array variable-length.

Original and re-encrypted iBSSs are now fully identical. (and  `tss_get_partial_hash` works with re-encrypted img3s)
