### PR TITLE
xpwntool.c update

### DIFF
--- a/ipsw-patch/xpwntool.c
+++ b/ipsw-patch/xpwntool.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "xpwn/libxpwn.h"
+#include "xpwn/img3.h"
 #include "xpwn/nor_files.h"
 
 #define BUFFERSIZE (1024*1024)


### PR DESCRIPTION
fixing: error: implicit declaration of function 'exploit24kpwn'

