### PR TITLE
changes to compile on linux with gcc v12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: Build and Push Docker Image to GHCR
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}:latest .
+
+      - name: Push Docker image
+        run: |
+          docker push ghcr.io/${{ github.repository }}:latest

--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,27 @@
+# Docker Usage Instructions
+
+### Setup
+
+Container images are available on [the GitHub Container Registry](https://github.com/orgs/malus-security/packages/container/package/xpwn) (and soon on the GitLab Container Registry).
+
+You can also build your own image locally:
+
+```sh
+docker build -t <container_name> .
+```
+
+### Usage
+
+The docker image is designed to run `xpwn` in the context of [iExtractor](https://github.com/malus-security/iextractor) and has the following default usage:
+
+```sh
+docker run -v <in_file>:/in -v <out_file>:/out -e IV=<iv> -e KEY=<key> -t <container_name>
+
+# runs this command: ./xpwntool /in /out -iv $IV -k $KEY -decrypt
+```
+
+However, it is possible to override the default flags:
+
+```sh
+docker run -t <container_name> --help
+``

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:latest
+
+RUN apt update && apt upgrade -y
+
+RUN apt install -y git cmake build-essential libz-dev libssl-dev libbz2-dev libpng-dev libusb-dev
+
+RUN git clone https://github.com/malus-security/xpwn.git
+
+WORKDIR /xpwn
+
+RUN git checkout testing
+
+RUN mkdir builddir
+
+WORKDIR /xpwn/builddir
+
+RUN cmake ..
+RUN make
+
+WORKDIR /
+
+ENTRYPOINT [ "/xpwn/builddir/ipsw-patch/xpwntool" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 FROM debian:latest
 
-RUN apt update && apt upgrade -y
+RUN set -xe; \
+    apt-get -yqq update; \
+    apt-get install -y cmake build-essential libz-dev libssl-dev libbz2-dev libpng-dev libusb-dev \
+    ;
 
-RUN apt install -y git cmake build-essential libz-dev libssl-dev libbz2-dev libpng-dev libusb-dev
-
-RUN git clone https://github.com/malus-security/xpwn.git
-
+COPY . /xpwn
 WORKDIR /xpwn
 
-RUN git checkout testing
-
 RUN mkdir builddir
-
 WORKDIR /xpwn/builddir
 
 RUN cmake ..
 RUN make
 
 WORKDIR /
+
+CMD [ "sh", "-c", "/xpwn/builddir/ipsw-patch/xpwntool /in /out -iv ${IV} -k ${KEY} -decrypt" ]
 
 ENTRYPOINT [ "/xpwn/builddir/ipsw-patch/xpwntool" ]

--- a/dfu-util/dfu.h
+++ b/dfu-util/dfu.h
@@ -104,5 +104,4 @@ char* dfu_state_to_string( int state );
 
 const char *dfu_status_to_string(int status);
 
-int debug;
 #endif

--- a/dfu-util/sam7dfu.c
+++ b/dfu-util/sam7dfu.c
@@ -20,6 +20,8 @@
 #define O_BINARY 0
 #endif
 
+extern int debug;
+
 /*
  *  * CRC32 code ripped off (and adapted) from the zlib-1.1.3 distribution by Jean-loup Gailly and Mark Adler.
  *   *

--- a/ipsw-patch/main.c
+++ b/ipsw-patch/main.c
@@ -19,7 +19,7 @@
 #include <windows.h>
 #endif
 
-char endianness;
+extern char endianness;
 
 static char* tmpFile = NULL;
 

--- a/xpwn/src/xpwn.cpp
+++ b/xpwn/src/xpwn.cpp
@@ -11,7 +11,7 @@
 using namespace ibooter;
 using namespace std;
 
-char endianness;
+extern char endianness;
 
 void TestByteOrder()
 {


### PR DESCRIPTION
### Made changes to compile the project on linux targets using gcc version 12.2.

- a variable named `debug` was defined in two places in `dfu-util/`
	- changed `dfu-util/dfu.h`: removed declaration of `debug` variable
	- changed `dfu-util/sam7dfu.c`: added extern declaration of `debug`
	- kept definition in `dfu-util/main.c`

- a variable named `endianness` was already defined and redefined inside `ipsw-patch/main.c` and `xpwn/src/xpwn.cpp`
	- added `extern` modifier to the declaration